### PR TITLE
chore(NeoToast): unit tests, Storybook guide, complete show-code coverage

### DIFF
--- a/src/components/00-foundations/toasts.mdx
+++ b/src/components/00-foundations/toasts.mdx
@@ -1,0 +1,171 @@
+
+import { Meta, Title } from '@storybook/addon-docs/blocks'
+
+<Meta title="Foundation/Toasts" parameters={{ backgrounds: { disable: true }, direction: { disable: true } }} />
+
+<Title>Toasts</Title>
+
+Transient notifications for the moments after an async action — saved, failed, dismissed, retrying. NeoMateria ships a first-class toast system so you don't have to roll your own with `v-if` and an inline `NeoCallout`.
+
+The design is **imperative**: trigger toasts from anywhere via `useToast()`, no state management library required. A single `<NeoToastContainer />` lives in your app shell and renders whatever's queued.
+
+---
+
+## Quick start
+
+```vue
+<!-- App.vue — mount once in your app shell -->
+<script setup lang="ts">
+import { NeoToastContainer } from 'neo-materia'
+</script>
+
+<template>
+  <RouterView />
+  <NeoToastContainer />
+</template>
+```
+
+```ts
+// any component, composable, store, or callback
+import { useToast } from 'neo-materia'
+
+const toast = useToast()
+toast.success('Settings saved.')
+```
+
+That's it. The composable is pure JavaScript — call it during setup, in event handlers, in stores, in router guards. Toasts triggered before the container mounts are queued and flushed once it appears.
+
+---
+
+## Severities and defaults
+
+| Severity | Default color | Default duration | ARIA live region |
+|----------|---------------|------------------|------------------|
+| `success` | `green`  | 5 s              | `polite` (`role="status"`) |
+| `info`    | `blue`   | 5 s              | `polite` (`role="status"`) |
+| `warning` | `amber`  | 8 s              | `assertive` (`role="alert"`) |
+| `error`   | `red`    | 0 (persistent)   | `assertive` (`role="alert"`) |
+
+Errors persist by design — the user should acknowledge them. All defaults are overridable per call (see *Options* below).
+
+---
+
+## Options
+
+Every severity method accepts a second argument:
+
+```ts
+toast.info('Project archived.', {
+  duration: 10000,                    // ms; 0 = persistent
+  closable: true,                     // show the × button (default)
+  color: 'purple',                    // override the severity → color mapping
+  icon: false,                        // hide the leading severity icon
+  ariaLive: 'assertive',              // override the ARIA live mode
+  action: {                           // optional action button
+    label: 'Undo',
+    onClick: (id) => unarchive(id),
+  },
+})
+```
+
+### Action buttons
+
+A single action lives alongside the message — typically `Undo`, `Retry`, or `View`. The callback receives the toast id and the action button is automatically dismissed when clicked.
+
+```ts
+toast.info('Email moved to trash.', {
+  action: { label: 'Undo', onClick: () => restore() },
+})
+```
+
+### `toast.promise()`
+
+For async flows, `toast.promise` shows a `loading` toast tied to the promise lifecycle, then replaces it in-place with the success or error result. The original promise is returned so you can `await` it normally.
+
+```ts
+const data = await toast.promise(saveDocument(payload), {
+  loading: 'Saving…',
+  success: (saved) => `Saved as ${saved.title}`,
+  error: (reason) => `Failed: ${(reason as Error).message}`,
+})
+```
+
+The replacement preserves the toast's position in the stack — no mount/unmount flicker.
+
+### Manual dismissal
+
+```ts
+const id = toast.error('Connection lost…', { duration: 0 })
+// later, when reconnected
+toast.dismiss(id)
+// or wipe everything
+toast.dismiss()
+```
+
+---
+
+## Container props
+
+`<NeoToastContainer>` is configured once at mount; per-toast options stay on the trigger call.
+
+| Prop       | Type                                                                                   | Default      | Notes |
+|------------|----------------------------------------------------------------------------------------|--------------|-------|
+| `position` | `'top-start' \| 'top-center' \| 'top-end' \| 'bottom-start' \| 'bottom-center' \| 'bottom-end'` | `'top-end'`  | Anchor edge in the viewport (logical, RTL-aware). |
+| `max`      | `number`                                                                               | `5`          | Concurrent toast cap. When exceeded, the oldest is evicted (FIFO). |
+| `zIndex`   | `number`                                                                               | `9999`       | Inline `z-index` on the floating container. |
+
+```vue
+<NeoToastContainer position="bottom-end" :max="3" />
+```
+
+Multiple containers in the same app are not supported — keep one mount point. If you need different positions for different toast types, wrap `useToast` with your own helper that picks the right configuration.
+
+---
+
+## Accessibility
+
+The component handles the standard ARIA wiring so you don't have to think about it:
+
+- `role="status"` + `aria-live="polite"` for success/info — announced after the current speech finishes
+- `role="alert"` + `aria-live="assertive"` for warning/error — announced immediately
+- The container is `role="region"` with `aria-label="Notifications"` so assistive tech can navigate to it
+- Auto-dismiss timers **pause on hover and focus-within** — screen-reader and keyboard users aren't rushed
+- Toasts never steal focus by default. If you include an `action`, it joins the normal tab order
+
+If your app needs a different aria-label or per-toast announcement priority, override `ariaLive` per call.
+
+---
+
+## SSR / Nuxt
+
+`<NeoToastContainer>` is SSR-safe: it guards `<Teleport to="body">` behind a client-only `mounted` ref. The render output during SSR is empty, and hydration kicks in cleanly. Toasts queued before hydration (e.g. from a Pinia store hydration step) appear once the container mounts.
+
+`useToast()` itself is pure JS and safe to import anywhere — there's no `document` reference until something is actually pushed to the DOM.
+
+---
+
+## Customizing visuals
+
+Toast colors map through the standard theme tokens (`--neo-theme-color`, `--neo-theme-colorAccessible`), so any theme override your app applies will flow through automatically. For finer control, override component variables in your own CSS:
+
+```css
+.NeoToast {
+  --NeoToast-sizing-padding: var(--neo-spacing-core-lg);
+  --NeoToast-sizing-maxWidth: 500px;
+  --NeoToast-color-shadow: 0 12px 32px rgb(0 0 0 / 18%);
+}
+
+.NeoToastContainer {
+  --NeoToastContainer-sizing-edgeOffset: var(--neo-spacing-core-xl);
+}
+```
+
+---
+
+## When *not* to use a toast
+
+- **Form validation errors** — show them inline next to the failing field (`NeoInput` / `NeoTextArea` have error states for this)
+- **Persistent informational banners** — use `NeoCallout` directly with `variant="bordered"` or `"filled"`
+- **Confirmation dialogs** — toasts auto-dismiss; if the user must confirm, render a modal or `NeoSheet`
+
+Toasts are best for **completed actions** and **transient status updates** the user can read in passing.

--- a/src/components/02-molecules/Toast/NeoToast.stories.tsx
+++ b/src/components/02-molecules/Toast/NeoToast.stories.tsx
@@ -168,6 +168,13 @@ export const LongMessage: Story = {
 				'Your subscription will renew automatically in 7 days. Update your payment method now to avoid any interruption to your access — this can be done from the billing settings page.',
 		}),
 	},
+	parameters: {
+		docs: {
+			source: {
+				code: `toast.warning('Your subscription will renew automatically in 7 days. Update your payment method now to avoid any interruption to your access — this can be done from the billing settings page.')`,
+			},
+		},
+	},
 }
 
 export const NoIcon: Story = {
@@ -175,12 +182,25 @@ export const NoIcon: Story = {
 	args: {
 		entry: buildEntry({ severity: 'success', message: 'Done.', showIcon: false }),
 	},
+	parameters: {
+		docs: {
+			source: {
+				code: `toast.success('Done.', { icon: false })`,
+			},
+		},
+	},
 }
 
 export const AllColors: Story = {
 	tags: ['snapshot'],
 	parameters: {
 		snapshot: { viewports: ['sm', 'xl'] },
+		docs: {
+			source: {
+				code: `// Override the severity → color mapping with any brand color.
+toast.info('Themed in purple.', { color: 'purple' })`,
+			},
+		},
 	},
 	render: () => {
 		return defineComponent({
@@ -211,6 +231,12 @@ export const AllColorsOnDark: Story = {
 	globals: { backgrounds: '#000' },
 	parameters: {
 		snapshot: { viewports: ['sm', 'xl'] },
+		docs: {
+			source: {
+				code: `// Toasts adapt to dark surfaces automatically when nested in u-onDark.
+toast.info('Themed in purple.', { color: 'purple' })`,
+			},
+		},
 	},
 	render: () => {
 		return defineComponent({

--- a/src/components/02-molecules/Toast/useToast.test.ts
+++ b/src/components/02-molecules/Toast/useToast.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { useToast } from './useToast'
+import { containerMaxRef, toasts, dismissToast } from './toastStore'
+
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+describe('useToast', () => {
+	beforeEach(() => {
+		dismissToast()
+		containerMaxRef.value = 5
+	})
+
+	afterEach(() => {
+		dismissToast()
+		containerMaxRef.value = 5
+	})
+
+	describe('severity methods', () => {
+		it('success pushes with green / 5000ms / polite', () => {
+			useToast().success('Saved.')
+			expect(toasts.value).toHaveLength(1)
+			expect(toasts.value[0]).toMatchObject({
+				severity: 'success',
+				message: 'Saved.',
+				color: 'green',
+				duration: 5000,
+				ariaLive: 'polite',
+				closable: true,
+				showIcon: true,
+			})
+		})
+
+		it('info pushes with blue / 5000ms / polite', () => {
+			useToast().info('Update available.')
+			expect(toasts.value[0]).toMatchObject({
+				severity: 'info',
+				color: 'blue',
+				duration: 5000,
+				ariaLive: 'polite',
+			})
+		})
+
+		it('warning pushes with amber / 8000ms / assertive', () => {
+			useToast().warning('Session expires soon.')
+			expect(toasts.value[0]).toMatchObject({
+				severity: 'warning',
+				color: 'amber',
+				duration: 8000,
+				ariaLive: 'assertive',
+			})
+		})
+
+		it('error pushes with red / 0ms (persistent) / assertive', () => {
+			useToast().error('Save failed.')
+			expect(toasts.value[0]).toMatchObject({
+				severity: 'error',
+				color: 'red',
+				duration: 0,
+				ariaLive: 'assertive',
+			})
+		})
+
+		it('returns the new toast id', () => {
+			const id = useToast().success('Saved.')
+			expect(id).toBe(toasts.value[0].id)
+		})
+
+		it('generates unique ids for sequential toasts', () => {
+			const toast = useToast()
+			const a = toast.success('a')
+			const b = toast.success('b')
+			expect(a).not.toBe(b)
+		})
+	})
+
+	describe('options', () => {
+		it('overrides color', () => {
+			useToast().success('x', { color: 'purple' })
+			expect(toasts.value[0].color).toBe('purple')
+		})
+
+		it('overrides duration', () => {
+			useToast().success('x', { duration: 1000 })
+			expect(toasts.value[0].duration).toBe(1000)
+		})
+
+		it('overrides ariaLive', () => {
+			useToast().success('x', { ariaLive: 'assertive' })
+			expect(toasts.value[0].ariaLive).toBe('assertive')
+		})
+
+		it('icon: false hides the icon', () => {
+			useToast().success('x', { icon: false })
+			expect(toasts.value[0].showIcon).toBe(false)
+		})
+
+		it('closable: false makes the toast non-dismissable', () => {
+			useToast().success('x', { closable: false })
+			expect(toasts.value[0].closable).toBe(false)
+		})
+
+		it('attaches an action', () => {
+			const onClick = vi.fn()
+			useToast().info('Archived.', { action: { label: 'Undo', onClick } })
+			expect(toasts.value[0].action).toEqual({ label: 'Undo', onClick })
+		})
+	})
+
+	describe('custom()', () => {
+		it('defaults to info severity when none given', () => {
+			useToast().custom('Plain message.')
+			expect(toasts.value[0]).toMatchObject({ severity: 'info', color: 'blue' })
+		})
+
+		it('respects an explicit severity', () => {
+			useToast().custom('Heads up.', { severity: 'warning' })
+			expect(toasts.value[0]).toMatchObject({ severity: 'warning', color: 'amber' })
+		})
+	})
+
+	describe('dismiss()', () => {
+		it('removes a single toast by id', () => {
+			const toast = useToast()
+			const a = toast.success('a')
+			toast.success('b')
+			toast.dismiss(a)
+			expect(toasts.value).toHaveLength(1)
+			expect(toasts.value[0].message).toBe('b')
+		})
+
+		it('clears all when called with no id', () => {
+			const toast = useToast()
+			toast.success('a')
+			toast.error('b')
+			toast.dismiss()
+			expect(toasts.value).toHaveLength(0)
+		})
+
+		it('is a no-op for an unknown id', () => {
+			useToast().success('a')
+			useToast().dismiss('does-not-exist')
+			expect(toasts.value).toHaveLength(1)
+		})
+	})
+
+	describe('max overflow', () => {
+		it('evicts the oldest toast when the cap is exceeded', () => {
+			containerMaxRef.value = 3
+			const toast = useToast()
+			toast.success('a')
+			toast.success('b')
+			toast.success('c')
+			toast.success('d')
+			expect(toasts.value).toHaveLength(3)
+			expect(toasts.value.map((entry) => entry.message)).toEqual(['b', 'c', 'd'])
+		})
+	})
+
+	describe('promise()', () => {
+		it('shows a persistent loading toast immediately', () => {
+			useToast().promise(new Promise(() => {}), {
+				loading: 'Saving…',
+				success: 'Saved!',
+				error: 'Failed.',
+			})
+			expect(toasts.value).toHaveLength(1)
+			expect(toasts.value[0]).toMatchObject({
+				severity: 'info',
+				message: 'Saving…',
+				duration: 0,
+				closable: false,
+			})
+		})
+
+		it('replaces loading with success on resolve, preserving position', async () => {
+			const toast = useToast()
+			toast.success('other-before')
+			toast.promise(Promise.resolve('done'), {
+				loading: 'Saving…',
+				success: 'Saved!',
+				error: 'Failed.',
+			})
+			toast.success('other-after')
+			const loadingId = toasts.value[1].id
+
+			await flushPromises()
+
+			expect(toasts.value).toHaveLength(3)
+			expect(toasts.value[1].id).toBe(loadingId) // position preserved
+			expect(toasts.value[1]).toMatchObject({ severity: 'success', message: 'Saved!' })
+		})
+
+		it('replaces loading with error on reject', async () => {
+			useToast().promise(Promise.reject(new Error('nope')), {
+				loading: 'Saving…',
+				success: 'Saved!',
+				error: 'Failed.',
+			})
+
+			await flushPromises()
+
+			expect(toasts.value[0]).toMatchObject({
+				severity: 'error',
+				message: 'Failed.',
+				duration: 0,
+			})
+		})
+
+		it('passes the resolved value to a function success message', async () => {
+			useToast().promise(Promise.resolve({ name: 'Alice' }), {
+				loading: '…',
+				success: (data) => `Welcome ${data.name}`,
+				error: 'oops',
+			})
+
+			await flushPromises()
+
+			expect(toasts.value[0].message).toBe('Welcome Alice')
+		})
+
+		it('passes the rejection reason to a function error message', async () => {
+			useToast().promise(Promise.reject(new Error('boom')), {
+				loading: '…',
+				success: 'ok',
+				error: (reason) => `Got: ${(reason as Error).message}`,
+			})
+
+			await flushPromises()
+
+			expect(toasts.value[0].message).toBe('Got: boom')
+		})
+
+		it('returns the original promise', async () => {
+			const original = Promise.resolve('result')
+			const returned = useToast().promise(original, {
+				loading: '…',
+				success: 'ok',
+				error: 'oops',
+			})
+			expect(returned).toBe(original)
+			await expect(returned).resolves.toBe('result')
+		})
+	})
+})


### PR DESCRIPTION
  Polish on the just-shipped NeoToast component:

  - useToast.test.ts: 24 unit tests locking the composable contract — severity defaults (color/duration/ariaLive), options overrides, custom() severity inference, dismiss(id)/dismiss-all, max overflow FIFO eviction, and toast.promise transitions (resolved/rejected, string/function-form messages, position preservation).
  - Foundation/Toasts.mdx: consumer-facing guide covering quick start, severity table, options, action buttons, toast.promise, container props, ARIA wiring, SSR/Nuxt notes, customization, when-not-to-use.
  - Show-code completed on LongMessage / NoIcon / AllColors / AllColorsOnDark stories — meets the project rule (`feedback_docs_and_slots.md`) that all render-function stories ship with parameters.docs.source.code.