### PR TITLE
test(ssr): add server-side rendering smoke tests for teleporting components

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 		"build": "npm run generate:files && vite build",
 		"prepublishOnly": "npm run build",
 		"preview": "vite preview",
-		"test": "npm run type-check && npm run lint:check && npm run stylelint:css && npm run prettier:check && vitest run --project=unit --project=snapshot-utils --project=storybook && npm run test:storybook:snapshots",
+		"test": "npm run type-check && npm run lint:check && npm run stylelint:css && npm run prettier:check && vitest run --project=unit --project=ssr --project=snapshot-utils --project=storybook && npm run test:storybook:snapshots",
 		"test:unit": "vitest --project=unit",
 		"test:storybook": "vitest run --project=storybook",
 		"test:storybook:snapshots": "node docker/run-snapshots.mjs",

--- a/src/components/02-molecules/Select/NeoSelect.ssr.test.ts
+++ b/src/components/02-molecules/Select/NeoSelect.ssr.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { createSSRApp } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import NeoSelect from './NeoSelect.vue'
+
+/**
+ * NeoSelect teleports its dropdown panel to `body`. All `window` listeners
+ * live inside open/close handlers, not setup, so SSR must render the trigger
+ * without throwing.
+ */
+
+describe('NeoSelect (SSR)', () => {
+	it('renders the trigger without throwing', async () => {
+		const app = createSSRApp({
+			components: { NeoSelect },
+			template: `
+				<NeoSelect
+					color="blue"
+					id="ssr-test"
+					name="ssr-test"
+					size="medium"
+					label="Pick one"
+					:options="options"
+				/>
+			`,
+			data() {
+				return {
+					options: [
+						{ value: 'a', label: 'Alpha' },
+						{ value: 'b', label: 'Beta' },
+					],
+				}
+			},
+		})
+		const html = await renderToString(app)
+		expect(html).toContain('Pick one')
+	})
+})

--- a/src/components/02-molecules/Sheet/NeoSheet.ssr.test.ts
+++ b/src/components/02-molecules/Sheet/NeoSheet.ssr.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { createSSRApp } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import NeoSheet from './NeoSheet.vue'
+
+/**
+ * NeoSheet uses `<Teleport to="body">`. During SSR there is no DOM to teleport
+ * to, so Vue inlines the teleported content. The setup script must not touch
+ * `document` or `window` at render time — those calls live in onMounted /
+ * event handlers and are skipped during SSR.
+ */
+
+describe('NeoSheet (SSR)', () => {
+	it('renders without throwing when closed (open=false)', async () => {
+		const app = createSSRApp({
+			components: { NeoSheet },
+			template: '<NeoSheet color="blue" :open="false" />',
+		})
+		await expect(renderToString(app)).resolves.toBeTypeOf('string')
+	})
+
+	it('renders without throwing when open=true', async () => {
+		const app = createSSRApp({
+			components: { NeoSheet },
+			template: '<NeoSheet color="blue" :open="true">content</NeoSheet>',
+		})
+		// Teleport produces placeholder markers during SSR (the real DOM move
+		// happens on hydration). Just confirming it renders without throwing.
+		const html = await renderToString(app)
+		expect(html).toBeTypeOf('string')
+	})
+
+	it('handles all positions without throwing', async () => {
+		for (const position of ['left', 'right', 'bottom']) {
+			const app = createSSRApp({
+				components: { NeoSheet },
+				template: `<NeoSheet color="blue" :open="true" position="${position}" />`,
+			})
+			await expect(renderToString(app)).resolves.toBeTypeOf('string')
+		}
+	})
+})

--- a/src/components/02-molecules/Toast/NeoToastContainer.ssr.test.ts
+++ b/src/components/02-molecules/Toast/NeoToastContainer.ssr.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { createSSRApp } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import NeoToastContainer from './NeoToastContainer.vue'
+import { useToast } from './useToast'
+import { dismissToast, toasts } from './toastStore'
+
+/**
+ * Pure-Node SSR smoke tests. No jsdom — `document` and `window` are undefined.
+ * Anything that touches the DOM unconditionally during setup/render will throw.
+ */
+
+describe('NeoToastContainer (SSR)', () => {
+	beforeEach(() => dismissToast())
+	afterEach(() => dismissToast())
+
+	it('document and window are undefined in this environment', () => {
+		expect(typeof document).toBe('undefined')
+		expect(typeof window).toBe('undefined')
+	})
+
+	it('renders to an empty string without throwing', async () => {
+		const app = createSSRApp(NeoToastContainer)
+		const html = await renderToString(app)
+		// Teleport is gated by a `mounted` ref so SSR output is empty —
+		// the actual DOM mount happens after hydration.
+		expect(html).toBe('<!---->')
+	})
+
+	it('renders cleanly even when toasts are queued before SSR', async () => {
+		// Simulate a store hydration step (or a router guard) pushing toasts before render.
+		useToast().success('Pre-render toast.')
+		expect(toasts.value).toHaveLength(1)
+
+		const app = createSSRApp(NeoToastContainer)
+		const html = await renderToString(app)
+		// Server output stays empty — toasts are still in the queue, waiting for hydration.
+		expect(html).toBe('<!---->')
+		expect(toasts.value).toHaveLength(1)
+	})
+
+	it('accepts position and max props without throwing', async () => {
+		const app = createSSRApp({
+			components: { NeoToastContainer },
+			template: '<NeoToastContainer position="bottom-center" :max="3" />',
+		})
+		await expect(renderToString(app)).resolves.toBe('<!---->')
+	})
+})

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -19,22 +19,22 @@ import { createSnapshotCommands } from './vitest.snapshot-commands'
 // same configDir, their names (and browser instance names) collide. This post-order
 // plugin restores the names we want after all other config hooks have run.
 function overrideProjectName(name: string): Plugin {
-  return {
-    name: 'vitest:project-name-override',
-    config: {
-      // Must be 'pre' so this hook runs before vitest:project:name (which has no
-      // hook order = normal). vitest:project:name reads test.name to build the
-      // workspaceNames filter list; if it reads the storybook:${dir} value the
-      // --project=<name> filter fails even though we later override the name.
-      order: 'pre',
-      handler() {
-        // storybook:workspace-name-override (also pre order, but listed earlier in
-        // the plugins array so it runs first) has set test.name = 'storybook:${dir}'.
-        // Restore it to the desired name so vitest:project:name picks up the right value.
-        return { test: { name } }
-      },
-    },
-  }
+	return {
+		name: 'vitest:project-name-override',
+		config: {
+			// Must be 'pre' so this hook runs before vitest:project:name (which has no
+			// hook order = normal). vitest:project:name reads test.name to build the
+			// workspaceNames filter list; if it reads the storybook:${dir} value the
+			// --project=<name> filter fails even though we later override the name.
+			order: 'pre',
+			handler() {
+				// storybook:workspace-name-override (also pre order, but listed earlier in
+				// the plugins array so it runs first) has set test.name = 'storybook:${dir}'.
+				// Restore it to the desired name so vitest:project:name picks up the right value.
+				return { test: { name } }
+			},
+		},
+	}
 }
 
 const projectRoot = fileURLToPath(new URL('.', import.meta.url))
@@ -45,13 +45,13 @@ const snapshotsModifiedDir = join(projectRoot, '__snapshots_modified__')
 // Clear diff and modified directories at the start of each run so only
 // current failures are visible — no stale images from previous runs.
 for (const dir of [snapshotsDiffDir, snapshotsModifiedDir]) {
-  if (existsSync(dir)) rmSync(dir, { recursive: true, force: true })
+	if (existsSync(dir)) rmSync(dir, { recursive: true, force: true })
 }
 
 const { compareSnapshot, prepareForSnapshot, captureStoryScreenshot } = createSnapshotCommands({
-  snapshots: snapshotsDir,
-  modified: snapshotsModifiedDir,
-  diff: snapshotsDiffDir,
+	snapshots: snapshotsDir,
+	modified: snapshotsModifiedDir,
+	diff: snapshotsDiffDir,
 })
 
 // Shared browser config injected into both storybook projects.
@@ -63,107 +63,123 @@ const snapshotBrowserCommands = { compareSnapshot, prepareForSnapshot, captureSt
 //   --disable-font-subpixel-positioning  no sub-pixel font placement
 //   --force-device-scale-factor=1        hard DPR=1 (overrides HiDPI displays)
 const chromiumInstance = {
-  browser: 'chromium',
-  launch: {
-    args: [
-      '--disable-lcd-text',
-      '--disable-font-subpixel-positioning',
-      '--force-device-scale-factor=1',
-    ],
-  },
-  context: { deviceScaleFactor: 1 },
+	browser: 'chromium',
+	launch: {
+		args: [
+			'--disable-lcd-text',
+			'--disable-font-subpixel-positioning',
+			'--force-device-scale-factor=1',
+		],
+	},
+	context: { deviceScaleFactor: 1 },
 }
 
-
 export default defineConfig({
-  plugins: [vue(), vueJsx()],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
-    },
-  },
-  test: {
-    exclude: [...configDefaults.exclude, 'e2e/**'],
-    root: fileURLToPath(new URL('./', import.meta.url)),
-    // Vitest sets updateSnapshot='none' automatically when process.env.CI is set,
-    // so CI never creates or updates built-in text snapshots. Our custom PNG
-    // comparison uses process.env.CI and UPDATE_SNAPSHOTS for the same effect.
-    projects: [
-      {
-        // Composable unit tests in jsdom
-        resolve: {
-          alias: {
-            '@': fileURLToPath(new URL('./src', import.meta.url)),
-          },
-        },
-        test: {
-          name: 'unit',
-          include: ['src/**/*.test.ts'],
-          environment: 'jsdom',
-        },
-      },
-      {
-        // Unit tests for the snapshot browser commands (Node.js environment)
-        test: {
-          name: 'snapshot-utils',
-          include: ['vitest.snapshot-commands.test.ts'],
-          environment: 'node',
-        },
-      },
-      {
-        // Storybook interaction + a11y tests (tag: test-only)
-        plugins: [
-          vue(),
-          vueJsx(),
-          storybookTest({ tags: { include: ['test-only'] } }),
-          overrideProjectName('storybook'),
-        ],
-        resolve: {
-          alias: {
-            '@': fileURLToPath(new URL('./src', import.meta.url)),
-          },
-        },
-        test: {
-          name: 'storybook',
-          browser: {
-            enabled: true,
-            headless: true,
-            provider: 'playwright',
+	plugins: [vue(), vueJsx()],
+	resolve: {
+		alias: {
+			'@': fileURLToPath(new URL('./src', import.meta.url)),
+		},
+	},
+	test: {
+		exclude: [...configDefaults.exclude, 'e2e/**'],
+		root: fileURLToPath(new URL('./', import.meta.url)),
+		// Vitest sets updateSnapshot='none' automatically when process.env.CI is set,
+		// so CI never creates or updates built-in text snapshots. Our custom PNG
+		// comparison uses process.env.CI and UPDATE_SNAPSHOTS for the same effect.
+		projects: [
+			{
+				// Composable unit tests in jsdom
+				resolve: {
+					alias: {
+						'@': fileURLToPath(new URL('./src', import.meta.url)),
+					},
+				},
+				test: {
+					name: 'unit',
+					include: ['src/**/*.test.ts'],
+					exclude: ['src/**/*.ssr.test.ts'],
+					environment: 'jsdom',
+				},
+			},
+			{
+				// Unit tests for the snapshot browser commands (Node.js environment)
+				test: {
+					name: 'snapshot-utils',
+					include: ['vitest.snapshot-commands.test.ts'],
+					environment: 'node',
+				},
+			},
+			{
+				// Server-side rendering smoke tests — pure Node, no DOM.
+				// Catches "document is not defined" regressions for components that
+				// teleport or otherwise touch the DOM, before they hit Nuxt consumers.
+				plugins: [vue(), vueJsx()],
+				resolve: {
+					alias: {
+						'@': fileURLToPath(new URL('./src', import.meta.url)),
+					},
+				},
+				test: {
+					name: 'ssr',
+					include: ['src/**/*.ssr.test.ts'],
+					environment: 'node',
+				},
+			},
+			{
+				// Storybook interaction + a11y tests (tag: test-only)
+				plugins: [
+					vue(),
+					vueJsx(),
+					storybookTest({ tags: { include: ['test-only'] } }),
+					overrideProjectName('storybook'),
+				],
+				resolve: {
+					alias: {
+						'@': fileURLToPath(new URL('./src', import.meta.url)),
+					},
+				},
+				test: {
+					name: 'storybook',
+					browser: {
+						enabled: true,
+						headless: true,
+						provider: 'playwright',
 
-            instances: [chromiumInstance],
-            commands: snapshotBrowserCommands,
-          },
-          setupFiles: ['.storybook/vitest.setup.ts'],
-        },
-      },
-      {
-        // Storybook visual snapshot tests (tag: snapshot)
-        plugins: [
-          vue(),
-          vueJsx(),
-          storybookTest({ tags: { include: ['snapshot'] } }),
-          overrideProjectName('storybook-snapshots'),
-        ],
-        resolve: {
-          alias: {
-            '@': fileURLToPath(new URL('./src', import.meta.url)),
-          },
-        },
-        test: {
-          name: 'storybook-snapshots',
-          // Each afterEach takes 3 viewport screenshots; allow extra time under load.
-          hookTimeout: 90_000,
-          browser: {
-            enabled: true,
-            headless: true,
-            provider: 'playwright',
+						instances: [chromiumInstance],
+						commands: snapshotBrowserCommands,
+					},
+					setupFiles: ['.storybook/vitest.setup.ts'],
+				},
+			},
+			{
+				// Storybook visual snapshot tests (tag: snapshot)
+				plugins: [
+					vue(),
+					vueJsx(),
+					storybookTest({ tags: { include: ['snapshot'] } }),
+					overrideProjectName('storybook-snapshots'),
+				],
+				resolve: {
+					alias: {
+						'@': fileURLToPath(new URL('./src', import.meta.url)),
+					},
+				},
+				test: {
+					name: 'storybook-snapshots',
+					// Each afterEach takes 3 viewport screenshots; allow extra time under load.
+					hookTimeout: 90_000,
+					browser: {
+						enabled: true,
+						headless: true,
+						provider: 'playwright',
 
-            instances: [chromiumInstance],
-            commands: snapshotBrowserCommands,
-          },
-          setupFiles: ['.storybook/vitest.setup.ts'],
-        },
-      },
-    ],
-  },
+						instances: [chromiumInstance],
+						commands: snapshotBrowserCommands,
+					},
+					setupFiles: ['.storybook/vitest.setup.ts'],
+				},
+			},
+		],
+	},
 })


### PR DESCRIPTION
  Adds a new `ssr` vitest project that runs in pure Node (no jsdom, no
  browser). Catches "document is not defined" regressions for components
  that touch the DOM, before they hit Nuxt or other SSR consumers.

  Coverage:
  - NeoToastContainer — verifies the mounted-gated Teleport produces empty output server-side, that toasts queued pre-render don't break SSR, and that position/max props pass through cleanly
  - NeoSheet — three positions render without throwing; Teleport produces placeholder markers as expected (real DOM move happens on hydration)
  - NeoSelect — trigger renders without throwing; dropdown panel only mounts on open so its window listeners stay quiet during SSR

  Config:
  - New `ssr` project in vitest.config.mts (Node env, vue + jsx plugins)
  - `unit` project excludes `*.ssr.test.ts` to prevent double-execution
  - `npm test` script picks up the new project